### PR TITLE
Remove debug print for t.RetweetedStatus(it may be <nil>)

### DIFF
--- a/cmd/gwitter.go
+++ b/cmd/gwitter.go
@@ -123,7 +123,6 @@ func printTweets(tweets []gwitter.Tweet) {
 		if len(t.InReplyToScreenName) > 0 {
 			fmt.Println("(In reply to: ", t.InReplyToScreenName, ")")
 		}
-		fmt.Println("RT status", t.RetweetedStatus)
 		if t.RetweetedStatus != nil {
 			rt := *t.RetweetedStatus
 			fmt.Println(term.FgWhite, "RT to ", term.FgYellow, rt.User.Name, term.FgWhite, "(@", rt.User.ScreenName, "):", term.FgBlue, rt.Text)


### PR DESCRIPTION
with debug print:
"
Go News (@golang_news) at Sun Jun 29 23:18:36 +0000 2014:
RT status <nil>
A comparison of Go to Rust and Haskell [xpost /r/rust] http://t.co/702XYt2oMW #reddit
"
as above, t.RetweetedStatus is nil
