### PR TITLE
changing url of api config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Gwitter is a Twitter client for the UNIX command line. Gwitter is written in Go.
 
 Current dependencies:
 * Go oauth library written by mrjones (https://github.com/mrjones/oauth) 
-* Gcfg Go ini config file library (https://code.google.com/p/gcfg/)
+* Gcfg Go ini config file library (https://gopkg.in/gcfg.v1)
 * Nothing else.
 
 This project is currently a toy, but will be expanded over time into a fully functioning client. Contributions are much welcome!

--- a/lib/config.go
+++ b/lib/config.go
@@ -14,7 +14,7 @@
 package gwitter 
 
 import (
-  "code.google.com/p/gcfg"
+  "gopkg.in/gcfg.v1"
 )
 
 type Config struct { 


### PR DESCRIPTION
The text-based configuration API has been migrated from https://code.google.com/p/gcfg/ to https://godoc.org/gopkg.in/gcfg.v1